### PR TITLE
Include plain 'glsl' extensions in fileTypes

### DIFF
--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -14,6 +14,7 @@
   'f.glsl'
   'v.glsl'
   'g.glsl'
+  'glsl'
 ]
 'foldingStartMarker': '/\\*\\*|\\{\\s*$'
 'foldingStopMarker': '\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
I often put common functions into '.glsl' files, then use a preprocessor to import them into vertex or fragment shaders.
