### PR TITLE
Add glsl file extensions

### DIFF
--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -11,6 +11,7 @@
   'vert'
   'frag'
   'geom'
+  'comp'
   'f.glsl'
   'v.glsl'
   'g.glsl'

--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -12,6 +12,8 @@
   'frag'
   'geom'
   'comp'
+  'tesc'
+  'tese'
   'f.glsl'
   'v.glsl'
   'g.glsl'


### PR DESCRIPTION
As per the [reference compiler implementation of GLSL](https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/), the file extensions include `comp`, `tesc`, and `tese`.
