### PR TITLE
Highlight ints

### DIFF
--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -26,7 +26,7 @@
   }
   {
     'match': '(?<!\\.)\\b[0-9]+\\b(?!\\.)'
-    'name': 'invalid.illegal.glsl'
+    'name': 'support.variable.glsl'
   }
   {
     'match': '\\b(break|case|continue|default|discard|do|else|for|if|return|switch|while)\\b'

--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -25,6 +25,10 @@
     'name': 'keyword.operator.glsl'
   }
   {
+    'match': '(?<!\\.)\\b[0-9]+\\b(?!\\.)'
+    'name': 'invalid.illegal.glsl'
+  }
+  {
     'match': '\\b(break|case|continue|default|discard|do|else|for|if|return|switch|while)\\b'
     'name': 'keyword.control.glsl'
   }

--- a/sample.glsl
+++ b/sample.glsl
@@ -14,6 +14,6 @@ void main() {
   vec3 a = noise(gl_FragColor.xy);
   vec3 b = y.xyz;
   float c = 1.0;
-  int d = 10;
+  int d = 190;
   a.xyz = gl_FragColor.xyz;
 }

--- a/sample.glsl
+++ b/sample.glsl
@@ -13,6 +13,7 @@
 void main() {
   vec3 a = noise(gl_FragColor.xy);
   vec3 b = y.xyz;
-
+  float c = 1.0;
+  int d = 10;
   a.xyz = gl_FragColor.xyz;
 }


### PR DESCRIPTION
![respectfulappropriateguineafowl-size_restricted](https://user-images.githubusercontent.com/2529989/30516294-ba769566-9b08-11e7-964e-3c5add1fe9e4.gif)

I feel like I spend 90% of my time in shaders dealing with:
  `cannot convert from 'const int' to 'highp float` 
  or some related problem.

Changing the highlighting to be different for ints and floats would help tremendously.