### PR TITLE
Add fx file extension support for BabylonJS

### DIFF
--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -1,6 +1,7 @@
 'fileTypes': [
   'vs'
   'fs'
+  'fx'
   'gs'
   'vsh'
   'fsh'


### PR DESCRIPTION
Fixes https://github.com/hughsk/language-glsl/issues/20

PS: We don't want only `.shader.fx` and `.vertex.fx` but but all `.fx` files (for includes)