### PR TITLE
Highlight ints

### DIFF
--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -26,7 +26,7 @@
   }
   {
     'match': '(?<!\\.)\\b[0-9]+\\b(?!\\.)'
-    'name': 'invalid.illegal.glsl'
+    'name': 'support.variable.glsl'
   }
   {
     'match': '\\b(break|case|continue|default|discard|do|else|for|if|return|switch|while)\\b'

--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -25,6 +25,10 @@
     'name': 'keyword.operator.glsl'
   }
   {
+    'match': '(?<!\\.)\\b[0-9]+\\b(?!\\.)'
+    'name': 'invalid.illegal.glsl'
+  }
+  {
     'match': '\\b(break|case|continue|default|discard|do|else|for|if|return|switch|while)\\b'
     'name': 'keyword.control.glsl'
   }

--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -32,7 +32,7 @@
   }
   {
     'match': '(?<!\\.)\\b[0-9]+\\b(?!\\.)'
-    'name': 'support.variable.glsl'
+    'name': 'constant.numeric.integer.glsl'
   }
   {
     'match': '\\b(break|case|continue|default|discard|do|else|for|if|return|switch|while)\\b'

--- a/sample.glsl
+++ b/sample.glsl
@@ -14,6 +14,6 @@ void main() {
   vec3 a = noise(gl_FragColor.xy);
   vec3 b = y.xyz;
   float c = 1.0;
-  int d = 10;
+  int d = 190;
   a.xyz = gl_FragColor.xyz;
 }

--- a/sample.glsl
+++ b/sample.glsl
@@ -13,6 +13,7 @@
 void main() {
   vec3 a = noise(gl_FragColor.xy);
   vec3 b = y.xyz;
-
+  float c = 1.0;
+  int d = 10;
   a.xyz = gl_FragColor.xyz;
 }


### PR DESCRIPTION
Broke this off from #19 so that I could resolve the conflicts and try the custom scope name. Seems to work well for me. I have the following in my `~/.atom/styles.less` to make ints stand out really well:

```css
atom-text-editor::shadow .constant.numeric.integer.glsl {
  color: red;
}
```

Without the custom style, it continues to look the same as before.