### PR TITLE
Added sksl

### DIFF
--- a/grammars/glsl.cson
+++ b/grammars/glsl.cson
@@ -22,6 +22,7 @@
   'v.glsl'
   'g.glsl'
   'glsl'
+  'sksl'
 ]
 'foldingStartMarker': '/\\*\\*|\\{\\s*$'
 'foldingStopMarker': '\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
The SKSL is the shader language created by Skia, that is the render of flutter, xamarin and delphi. It is a derivative of GLSL, so it has the same gramma, and can be included in this package.